### PR TITLE
Add --format option to format the ETA into days, hours, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Stats are updated every second.
 
 - `-s, --size <size>`: Assume the total amount of data to be transferred is SIZE. You can provide a size in bytes or using units (`b, kb, mb, gb, tb`).
 - `-N, --name <name>`: Prefix the output information with NAME.
+- `-f, --format`: Format the ETA as days, hours, minutes, and seconds.  E.g. `6d 5h 43m 21s` or `3m 21s` instead of the default, which is `539001` or `201`.
 
 ## Programmatic usage
 

--- a/bin/pv.js
+++ b/bin/pv.js
@@ -4,6 +4,7 @@ var PV = require('../index')
 var bytes = require('bytes')
 var argv = require('minimist')(process.argv.slice(2), {alias: {
   'size': 's',
+  'format': 'f',
   'name': 'N',
   'version': 'v'
 }})
@@ -24,7 +25,7 @@ pv.on('info', function (info) {
   var percentage = info.percentage + '%'
   var speed = info.speed + '/s'
   var transferred = info.transferred + ' Transferred'
-  var eta = info.eta + ' ETA'
+  var eta = (argv.format ? formatEta(info.eta) : info.eta) + ' ETA'
   stderr(`${name} ${percentage} | ${eta} | ${transferred} | ${speed}`)
 })
 
@@ -35,4 +36,21 @@ function stderr (str) {
   process.stderr.clearLine() // clear current text
   process.stderr.cursorTo(0) // move cursor to beginning of line
   process.stderr.write(str)
+}
+
+function formatEta (eta) {
+  var days = Math.floor(eta / (60 * 60 * 24))
+  var hours = Math.floor(eta / (60 * 60)) % 24
+  var minutes = Math.floor(eta / 60) % 60
+  var seconds = Math.floor(eta) % 60
+
+  if (days) {
+    return days + 'd ' + hours + 'h ' + minutes + 'm ' + seconds + 's'
+  } else if (hours) {
+    return hours + 'h ' + minutes + 'm ' + seconds + 's'
+  } else if (minutes) {
+    return minutes + 'm ' + seconds + 's'
+  } else {
+    return seconds + 's'
+  }
 }


### PR DESCRIPTION
You can now format an ETA to look like this: `11d 0h 8m 53s ETA`
Instead of just looking like this: `950933 ETA`